### PR TITLE
Suporte ao Wokwi e adição funções de processamento dos comandos via UART

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,70 +1,78 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Pico Debug (Cortex-Debug)",
-            "cwd": "${userHome}/.pico-sdk/openocd/0.12.0+dev/scripts",
-            "executable": "${command:raspberry-pi-pico.launchTargetPath}",
-            "request": "launch",
-            "type": "cortex-debug",
-            "servertype": "openocd",
-            "serverpath": "${userHome}/.pico-sdk/openocd/0.12.0+dev/openocd.exe",
-            "gdbPath": "${command:raspberry-pi-pico.getGDBPath}",
-            "device": "${command:raspberry-pi-pico.getChipUppercase}",
-            "configFiles": [
-                "interface/cmsis-dap.cfg",
-                "target/${command:raspberry-pi-pico.getTarget}.cfg"
-            ],
-            "svdFile": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd",
-            "runToEntryPoint": "main",
-            // Fix for no_flash binaries, where monitor reset halt doesn't do what is expected
-            // Also works fine for flash binaries
-            "overrideLaunchCommands": [
-                "monitor reset init",
-                "load \"${command:raspberry-pi-pico.launchTargetPath}\""
-            ],
-            "openOCDLaunchCommands": [
-                "adapter speed 5000"
-            ]
-        },
-        {
-            "name": "Pico Debug (Cortex-Debug with external OpenOCD)",
-            "cwd": "${workspaceRoot}",
-            "executable": "${command:raspberry-pi-pico.launchTargetPath}",
-            "request": "launch",
-            "type": "cortex-debug",
-            "servertype": "external",
-            "gdbTarget": "localhost:3333",
-            "gdbPath": "${command:raspberry-pi-pico.getGDBPath}",
-            "device": "${command:raspberry-pi-pico.getChipUppercase}",
-            "svdFile": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd",
-            "runToEntryPoint": "main",
-            // Fix for no_flash binaries, where monitor reset halt doesn't do what is expected
-            // Also works fine for flash binaries
-            "overrideLaunchCommands": [
-                "monitor reset init",
-                "load \"${command:raspberry-pi-pico.launchTargetPath}\""
-            ]
-        },
-        {
-            "name": "Pico Debug (C++ Debugger)",
-            "type": "cppdbg",
-            "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "program": "${command:raspberry-pi-pico.launchTargetPath}",
-            "MIMode": "gdb",
-            "miDebuggerPath": "${command:raspberry-pi-pico.getGDBPath}",
-            "miDebuggerServerAddress": "localhost:3333",
-            "debugServerPath": "${userHome}/.pico-sdk/openocd/0.12.0+dev/openocd.exe",
-            "debugServerArgs": "-f interface/cmsis-dap.cfg -f target/${command:raspberry-pi-pico.getTarget}.cfg -c \"adapter speed 5000\"",
-            "serverStarted": "Listening on port .* for gdb connections",
-            "filterStderr": true,
-            "hardwareBreakpoints": {
-                "require": true,
-                "limit": 4
-            },
-            "preLaunchTask": "Flash",
-            "svdPath": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd"
-        },
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Pico Debug (Cortex-Debug)",
+      "cwd": "${userHome}/.pico-sdk/openocd/0.12.0+dev/scripts",
+      "executable": "${command:raspberry-pi-pico.launchTargetPath}",
+      "request": "launch",
+      "type": "cortex-debug",
+      "servertype": "openocd",
+      "serverpath": "${userHome}/.pico-sdk/openocd/0.12.0+dev/openocd.exe",
+      "gdbPath": "${command:raspberry-pi-pico.getGDBPath}",
+      "device": "${command:raspberry-pi-pico.getChipUppercase}",
+      "configFiles": [
+        "interface/cmsis-dap.cfg",
+        "target/${command:raspberry-pi-pico.getTarget}.cfg"
+      ],
+      "svdFile": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd",
+      "runToEntryPoint": "main",
+      // Fix for no_flash binaries, where monitor reset halt doesn't do what is expected
+      // Also works fine for flash binaries
+      "overrideLaunchCommands": [
+        "monitor reset init",
+        "load \"${command:raspberry-pi-pico.launchTargetPath}\""
+      ],
+      "openOCDLaunchCommands": ["adapter speed 5000"]
+    },
+    {
+      "name": "Pico Debug (Cortex-Debug with external OpenOCD)",
+      "cwd": "${workspaceRoot}",
+      "executable": "${command:raspberry-pi-pico.launchTargetPath}",
+      "request": "launch",
+      "type": "cortex-debug",
+      "servertype": "external",
+      "gdbTarget": "localhost:3333",
+      "gdbPath": "${command:raspberry-pi-pico.getGDBPath}",
+      "device": "${command:raspberry-pi-pico.getChipUppercase}",
+      "svdFile": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd",
+      "runToEntryPoint": "main",
+      // Fix for no_flash binaries, where monitor reset halt doesn't do what is expected
+      // Also works fine for flash binaries
+      "overrideLaunchCommands": [
+        "monitor reset init",
+        "load \"${command:raspberry-pi-pico.launchTargetPath}\""
+      ]
+    },
+    {
+      "name": "Pico Debug (C++ Debugger)",
+      "type": "cppdbg",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${command:raspberry-pi-pico.launchTargetPath}",
+      "MIMode": "gdb",
+      "miDebuggerPath": "${command:raspberry-pi-pico.getGDBPath}",
+      "miDebuggerServerAddress": "localhost:3333",
+      "debugServerPath": "${userHome}/.pico-sdk/openocd/0.12.0+dev/openocd.exe",
+      "debugServerArgs": "-f interface/cmsis-dap.cfg -f target/${command:raspberry-pi-pico.getTarget}.cfg -c \"adapter speed 5000\"",
+      "serverStarted": "Listening on port .* for gdb connections",
+      "filterStderr": true,
+      "hardwareBreakpoints": {
+        "require": true,
+        "limit": 4
+      },
+      "preLaunchTask": "Flash",
+      "svdPath": "${userHome}/.pico-sdk/sdk/2.1.0/src/${command:raspberry-pi-pico.getChip}/hardware_regs/${command:raspberry-pi-pico.getChipUppercase}.svd"
+    },
+    {
+      "name": "Wokwi GDB",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/your-firmware.elf",
+      "cwd": "${workspaceFolder}",
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/local/bin/xtensa-esp32-elf-gdb",
+      "miDebuggerServerAddress": "localhost:3333"
+    }
+  ]
 }

--- a/LedBuzz.c
+++ b/LedBuzz.c
@@ -77,5 +77,30 @@ int main()
 
     printf("Programa inicializado. Aguardando comandos...\n");
 
+    char command[32];
+    while (true) {
+        // Lê o comando via UART
+        if (uart_is_readable(UART_ID)) {
+            int index = 0;
+            while (index < sizeof(command) - 1) {
+                int character = uart_getc(UART_ID);
+                if (character != PICO_ERROR_TIMEOUT) {
+                    command[index++] = (char)character;
+                    if (character == '\n' || character == '\r') {
+                        break;
+                    }
+                }
+            }
+            command[index] = '\0';
+            if (index > 0) {
+                process_command(command);
+            }
+        } else {
+            if (scanf("%32s", command) == 1) {
+                process_command(command);
+            }
+        }
+    }
+
     return 0;
 }

--- a/LedBuzz.c
+++ b/LedBuzz.c
@@ -42,6 +42,30 @@ void initialize_gpio() {
     gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
 }
 
+// Função para processar comandos recebidos
+void process_command(const char *command) {
+    if (strcmp(command, "Vermelho") == 0) {
+        turn_on_led(LED_VERMELHO);
+    } else if (strcmp(command, "Azul") == 0) {
+        turn_on_led(LED_AZUL);
+    } else if (strcmp(command, "Verde") == 0) {
+        turn_on_led(LED_VERDE);
+    } else if (strcmp(command, "Branco") == 0) {
+        turn_on_all_leds();
+    } else if (strcmp(command, "Desligar") == 0) {
+        turn_off_leds();
+    } else if (strcmp(command, "BuzzerA") == 0) {
+        activate_buzzer(BUZZER_A);
+    } else if (strcmp(command, "BuzzerB") == 0) {
+        activate_buzzer(BUZZER_B);
+    } else {
+        printf("Comando desconhecido: %s\n", command);
+        return;
+    }
+
+    printf("Comando processado: %s\n", command);
+}
+
 int main()
 {
     stdio_init_all();

--- a/LedBuzz.c
+++ b/LedBuzz.c
@@ -2,39 +2,56 @@
 #include "pico/stdlib.h"
 #include "hardware/uart.h"
 
-// UART defines
-// By default the stdout UART is `uart0`, so we will use the second one
+// Definições da UART
+// Por padrão, a UART stdout é `uart0`, então usaremos a segunda
 #define UART_ID uart1
 #define BAUD_RATE 115200
 
-// Use pins 4 and 5 for UART1
-// Pins can be changed, see the GPIO function select table in the datasheet for information on GPIO assignments
+// Usar os pinos 4 e 5 para UART1
+// Os pinos podem ser alterados, veja a tabela de seleção de função GPIO no datasheet para informações sobre atribuições de GPIO
 #define UART_TX_PIN 4
 #define UART_RX_PIN 5
 
+// Definindo os GPIOs
+#define LED_VERMELHO 13
+#define LED_AZUL 12
+#define LED_VERDE 11
+#define BUZZER_A 21
+#define BUZZER_B 10
 
+// Função de inicialização das GPIOs
+void initialize_gpio() {
+    gpio_init(LED_VERMELHO);
+    gpio_set_dir(LED_VERMELHO, GPIO_OUT);
+
+    gpio_init(LED_AZUL);
+    gpio_set_dir(LED_AZUL, GPIO_OUT);
+
+    gpio_init(LED_VERDE);
+    gpio_set_dir(LED_VERDE, GPIO_OUT);
+
+    gpio_init(BUZZER_A);
+    gpio_set_dir(BUZZER_A, GPIO_OUT);
+
+    gpio_init(BUZZER_B);
+    gpio_set_dir(BUZZER_B, GPIO_OUT);
+
+    // Inicializa a UART
+    uart_init(UART_ID, BAUD_RATE);
+    gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
+    gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
+}
 
 int main()
 {
     stdio_init_all();
 
-    // Set up our UART
-    uart_init(UART_ID, BAUD_RATE);
-    // Set the TX and RX pins by using the function select on the GPIO
-    // Set datasheet for more information on function select
-    gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
-    gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
-    
-    // Use some the various UART functions to send out data
-    // In a default system, printf will also output via the default UART
-    
-    // Send out a string, with CR/LF conversions
-    uart_puts(UART_ID, " Hello, UART!\n");
-    
-    // For more examples of UART use see https://github.com/raspberrypi/pico-examples/tree/master/uart
+    initialize_gpio();
 
-    while (true) {
-        printf("Hello, world!\n");
-        sleep_ms(1000);
-    }
+    // Envia uma string de teste na UART
+    uart_puts(UART_ID, "Olá, UART!\n");
+
+    printf("Programa inicializado. Aguardando comandos...\n");
+
+    return 0;
 }

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "author": "Wilson Oliveira Lima",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "board-pi-pico-w", "id": "pico", "top": 0, "left": 0, "attrs": {} },
+    { "type": "wokwi-led", "id": "led1", "top": 6, "left": -178.6, "attrs": { "color": "red" } },
+    {
+      "type": "wokwi-resistor",
+      "id": "r1",
+      "top": 139.2,
+      "left": -192.55,
+      "rotate": 90,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led2",
+      "top": -70.8,
+      "left": -149.8,
+      "attrs": { "color": "blue" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r2",
+      "top": 43.2,
+      "left": -163.75,
+      "rotate": 90,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led3",
+      "top": -109.2,
+      "left": -111.4,
+      "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r3",
+      "top": 24,
+      "left": -125.35,
+      "rotate": 90,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-buzzer",
+      "id": "bz1",
+      "top": -170.4,
+      "left": -75,
+      "attrs": { "volume": "0.1" }
+    },
+    {
+      "type": "wokwi-buzzer",
+      "id": "bz2",
+      "top": 31.2,
+      "left": 136.2,
+      "attrs": { "volume": "0.1" }
+    }
+  ],
+  "connections": [
+    [ "pico:GP0", "$serialMonitor:RX", "", [] ],
+    [ "pico:GP1", "$serialMonitor:TX", "", [] ],
+    [ "led1:C", "r1:1", "green", [ "v0" ] ],
+    [ "r1:2", "pico:GND.4", "green", [ "h0" ] ],
+    [ "led1:A", "pico:GP13", "green", [ "v0" ] ],
+    [ "pico:GP12", "led2:A", "green", [ "h0" ] ],
+    [ "r2:1", "led2:C", "green", [ "h0" ] ],
+    [ "r2:2", "pico:GND.4", "green", [ "h0", "v66" ] ],
+    [ "led3:A", "pico:GP11", "green", [ "v0" ] ],
+    [ "led3:C", "r3:1", "green", [ "v0" ] ],
+    [ "r3:2", "pico:GND.4", "green", [ "h0", "v123.6" ] ],
+    [ "pico:GP21", "bz2:2", "green", [ "h0" ] ],
+    [ "bz2:1", "pico:GND.6", "green", [ "v0" ] ],
+    [ "pico:GP10", "bz1:2", "green", [ "h0" ] ],
+    [ "bz1:1", "pico:GND.3", "green", [ "v0" ] ]
+  ],
+  "dependencies": {}
+}

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,5 @@
+[wokwi]
+version = 1
+firmware = 'build/LedBuzz.uf2'
+elf = 'build/LedBuzz.elf'
+gdbServerPort=3333


### PR DESCRIPTION
Adição dos arquivos de configuração do Wokwi para rodar o projeto no simulador. Criação das funções de inicialização do GPIO e o processamento de comandos para controlar LEDs e Buzzers usando a porta serial UART.